### PR TITLE
add fakeconfig file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 config.env
-config/
 .prettierrc
 node_modules/
 package-lock.json

--- a/server/config/fakeconfig.env
+++ b/server/config/fakeconfig.env
@@ -1,0 +1,4 @@
+NODE_ENV=development
+PORT = 5500
+MONGODB_URI=mongodb+srv://fakeuser:<password>@sshsmartcart.l7afz.mongodb.net/fakedb?retryWrites=true&w=majority&appName=fakeappname
+DATABASE_PASSWORD = fakepassword


### PR DESCRIPTION
This adds a fake config file in order to show the person marking this repository what the config file would look like to allow them to have a concrete example of how our code would work without needing to actually see the information in the real config file.  